### PR TITLE
Slack rtm spoof

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -88,6 +88,7 @@ type ChannelMembers []ChannelMember
 
 type Protocol struct {
 	AllowMention           []string // discord
+	AppToken               string   // slack
 	AuthCode               string   // steam
 	BindAddress            string   // mattermost, slack // DEPRECATED
 	Buffer                 int      // api
@@ -134,6 +135,7 @@ type Protocol struct {
 	NoHomeServerSuffix     bool       // matrix
 	NoSendJoinPart         bool       // all protocols
 	NoTLS                  bool       // mattermost, xmpp
+	NoUserSpoofing         bool       // slack
 	Password               string     // IRC,mattermost,XMPP,matrix
 	PrefixMessagesWithNick bool       // mattemost, slack
 	PreserveThreading      bool       // slack
@@ -163,7 +165,6 @@ type Protocol struct {
 	TeamID                 string     // msteams
 	TenantID               string     // msteams
 	Token                  string     // gitter, slack, discord, api, matrix
-	AppToken               string     // slack
 	Topic                  string     // zulip
 	URL                    string     // mattermost, slack // DEPRECATED
 	UseAPI                 bool       // mattermost, slack

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -64,6 +64,7 @@ const (
 	outgoingWebhookConfig = "WebhookURL"
 	skipTLSConfig         = "SkipTLSVerify"
 	useNickPrefixConfig   = "PrefixMessagesWithNick"
+	noUserSpoofing        = "NoUserSpoofing"
 	editDisableConfig     = "EditDisable"
 	editSuffixConfig      = "EditSuffix"
 	iconURLConfig         = "iconurl"
@@ -532,8 +533,8 @@ func (b *Bslack) uploadFile(msg *config.Message, channelID string) (string, erro
 
 func (b *Bslack) prepareMessageOptions(msg *config.Message) []slack.MsgOption {
 	params := slack.NewPostMessageParameters()
-	if b.GetBool(useNickPrefixConfig) {
-		params.AsUser = true
+	if b.GetBool(noUserSpoofing) {
+		params.AsUser = true // This flag appears to disable user-spoofing when using a non-classic bot
 	}
 	params.Username = msg.Username
 	params.LinkNames = 1 // replace mentions

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -112,6 +112,9 @@ func (b *Bslack) Connect() error {
 	// If we have a token we use the Slack websocket-based RTM for both sending and receiving.
 	if token := b.GetString(tokenConfig); token != "" {
 		b.Log.Info("Connecting using token")
+		if b.GetBool(noUserSpoofing) {
+			b.Log.Infof("%s: `NoUserSpoofing=true` while in RTM (Token) mode - User spoofing has been disabled for this bridge.", b.Account)
+		}
 
 		appToken := b.GetString(appTokenConfig)
 		b.sc = slack.New(token, slack.OptionDebug(b.GetBool("Debug")), slack.OptionAppLevelToken(appToken))


### PR DESCRIPTION
Fixes issue #1: PrefixMessagesWithNick in slack bridges breaks user-spoofing