### PR TITLE
Fix #6

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -138,6 +138,7 @@ type Protocol struct {
 	NoUserSpoofing         bool       // slack
 	Password               string     // IRC,mattermost,XMPP,matrix
 	PrefixMessagesWithNick bool       // mattemost, slack
+	PreferSpoofOverThread  bool       // mattemost
 	PreserveThreading      bool       // slack
 	Protocol               string     // all protocols
 	QuoteDisable           bool       // telegram


### PR DESCRIPTION
From Issue:
> Additional context
> This issue means user has to choose between spoofing messages using webhook (doesn't support threads), or using the api to create posts in threads (doesn't support spoofing)
> The API's PatchPost-route does not support patching in a root_id either, so unable to post in channel and then patch it into a thread.

As it is not possible to fix it so threads are created by the webhook, either some other method has to be figured out to achieve it without losing the spoofing functionality, or user needs to be able to set an option for whether to use the regular API as fallback.

- [x] Create a fallback that uses the regular API, where user can set an option to select thread-behaviour (retain spoof vs retain thread).
  - [ ] Implement some behaviour for when the regular API (which is used as the fallback) is inaccessible (lacking `Token`).
- [ ] Figure out and Implement some method to fix threading without losing features in the process.
- [ ] Investigate https://github.com/42wim/matterbridge/pull/1574 to see if the referenced bug is still a thing, and if the fix still makes sense.